### PR TITLE
Refactor: Shell Application에 Command Pattern 적용

### DIFF
--- a/src/ssd/__main__.py
+++ b/src/ssd/__main__.py
@@ -7,6 +7,8 @@ from ssd.driver.virtual import VirtualSSD
 def get_args() -> (str, int, int):
     try:
         cmd = sys.argv[1].upper()
+        if cmd == "F":
+            return cmd, None, None
         addr = int(sys.argv[2])
         if cmd == "R":
             return cmd, addr, None
@@ -14,8 +16,6 @@ def get_args() -> (str, int, int):
             return cmd, addr, int(sys.argv[3], 16)
         if cmd == "E":
             return cmd, addr, int(sys.argv[3])
-        if cmd == "F":
-            return cmd, None, None
     except IndexError:
         return None, None, None
 

--- a/src/ssd/shell/api.py
+++ b/src/ssd/shell/api.py
@@ -130,3 +130,6 @@ class Shell:
                 self.logger.print("Fail")
                 return
         self.logger.print("Success")
+
+    def flush(self):
+        os.system(f"python -m ssd F")

--- a/src/ssd/shell/api.py
+++ b/src/ssd/shell/api.py
@@ -30,7 +30,13 @@ class Shell:
         f"fullwrite: Write value (0xXXXXXXXX) to entire address\n"
         f"\tfullwrite [value]\n"
         f"fullread: Read value of entire address\n"
-        f"\tfullread"
+        f"\tfullread\n"
+        f"erase: Erase value amount of size from address\n"
+        f"\terase [address] [size]\n"
+        f"erase_range: Erase value from start (include) to end (exclude)\n"
+        f"\terase_range [start address] [end address]\n"
+        f"flush: Flush all commands in buffer\n"
+        f"\tflush\n"
     )
 
     def __init__(self, result_reader: ResultReader):

--- a/src/ssd/shell/api.py
+++ b/src/ssd/shell/api.py
@@ -110,7 +110,7 @@ class Shell:
             result.append(self.read(lba))
         return result
 
-    def testapp1(self):
+    def testapp1(self):  # TODO: remove this
         test_value = "0xAAAAAAAA"
         self.fullwrite(test_value)
         data = self.fullread()
@@ -120,7 +120,7 @@ class Shell:
                 return
         self.logger.print("Success")
 
-    def testapp2(self):
+    def testapp2(self):  # TODO: remove this
         test_value1 = "0xAAAABBBB"
         test_value2 = "0x12345678"
         for _ in range(30):

--- a/src/ssd/shell/app/cli.py
+++ b/src/ssd/shell/app/cli.py
@@ -30,6 +30,11 @@ class SsdTestShellApp(cmd.Cmd):
         return True
 
     def do_help(self, args):
+        """
+        Notice
+        `help` 입력 시 self.default()로 가지 않고 super.do_help()가 실행되기에
+        별도로 HelpCommand 만들지 않고 override 했습니다.
+        """
         self.ssd_ctrl.help()
 
     def default(self, args: str):

--- a/src/ssd/shell/app/cli.py
+++ b/src/ssd/shell/app/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from ssd.shell.api import ResultReader, Shell
 from ssd.shell.app.script_manager import ScriptManager
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 from ssd.shell.cmd.factory import ShellCommandFactory
 from ssd.util.logger import Logger
 
@@ -42,13 +42,13 @@ class SsdTestShellApp(cmd.Cmd):
 
         self._run_script(_script_path)
 
-    def _interpret_as_ssd_command(self, args: str) -> IShellCommand | None:
+    def _interpret_as_ssd_command(self, args: str) -> ShellCommandInterface | None:
         try:
             return self._cmd_factory.parse(args)
         except ValueError:
             return None
 
-    def _run_ssd_cmd(self, ssd_cmd: IShellCommand):
+    def _run_ssd_cmd(self, ssd_cmd: ShellCommandInterface):
         try:
             ssd_cmd.execute()
         except Exception as e:

--- a/src/ssd/shell/app/script_manager.py
+++ b/src/ssd/shell/app/script_manager.py
@@ -8,7 +8,7 @@ class ScriptManager:
 
     script_dir = Path(Logger.find_git_root()).joinpath("src/script")
 
-    def find(self, script_name: str):
+    def find(self, script_name: str) -> Path:
         script_path = self.script_dir / f"{script_name}.py"
         if not script_path.exists():
             raise FileNotFoundError(f"{script_name}")

--- a/src/ssd/shell/cmd/base.py
+++ b/src/ssd/shell/cmd/base.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+
+from ssd.shell.api import Shell
+
+
+class IShellCommand(ABC):
+    def __init__(self, api: Shell, args: list[str]):
+        self.api = api
+        self.args = args
+
+    @abstractmethod
+    def is_valid(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def execute(self) -> None:
+        raise NotImplementedError

--- a/src/ssd/shell/cmd/base.py
+++ b/src/ssd/shell/cmd/base.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from ssd.shell.api import Shell
 
 
-class IShellCommand(ABC):
+class ShellCommandInterface(ABC):
     def __init__(self, api: Shell, args: list[str]):
         self.api = api
         self.args = args

--- a/src/ssd/shell/cmd/erase.py
+++ b/src/ssd/shell/cmd/erase.py
@@ -1,0 +1,24 @@
+from ssd.shell.api import Shell
+from ssd.shell.cmd.base import IShellCommand
+
+
+class EraseCommand(IShellCommand):
+    def __init__(self, api: Shell, args: list[str]):
+        super().__init__(api, args)
+        self.address = 0
+        self.size = 0
+
+    def is_valid(self) -> bool:
+        if (
+            len(self.args) != 2
+            or not self.args[0].isdigit()
+            or not self.args[1].isdigit()
+        ):
+            return False
+        self.address, self.size = map(int, self.args)
+        return True
+
+    def execute(self) -> None:
+        if not self.is_valid():
+            self.api.help()
+        self.api.erase(self.address, self.size)

--- a/src/ssd/shell/cmd/erase.py
+++ b/src/ssd/shell/cmd/erase.py
@@ -21,4 +21,5 @@ class EraseCommand(IShellCommand):
     def execute(self) -> None:
         if not self.is_valid():
             self.api.help()
+            return
         self.api.erase(self.address, self.size)

--- a/src/ssd/shell/cmd/erase.py
+++ b/src/ssd/shell/cmd/erase.py
@@ -1,8 +1,8 @@
 from ssd.shell.api import Shell
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 
 
-class EraseCommand(IShellCommand):
+class EraseCommand(ShellCommandInterface):
     def __init__(self, api: Shell, args: list[str]):
         super().__init__(api, args)
         self.address = 0

--- a/src/ssd/shell/cmd/erase_range.py
+++ b/src/ssd/shell/cmd/erase_range.py
@@ -21,4 +21,5 @@ class EraseRangeCommand(IShellCommand):
     def execute(self) -> None:
         if not self.is_valid():
             self.api.help()
+            return
         self.api.erase_range(self.start_addr, self.end_addr)

--- a/src/ssd/shell/cmd/erase_range.py
+++ b/src/ssd/shell/cmd/erase_range.py
@@ -1,0 +1,24 @@
+from ssd.shell.api import Shell
+from ssd.shell.cmd.base import IShellCommand
+
+
+class EraseRangeCommand(IShellCommand):
+    def __init__(self, api: Shell, args: list[str]):
+        super().__init__(api, args)
+        self.start_addr = 0
+        self.end_addr = 0
+
+    def is_valid(self) -> bool:
+        if (
+            len(self.args) != 2
+            or not self.args[0].isdigit()
+            or not self.args[1].isdigit()
+        ):
+            return False
+        self.start_addr, self.end_addr = map(int, self.args)
+        return True
+
+    def execute(self) -> None:
+        if not self.is_valid():
+            self.api.help()
+        self.api.erase_range(self.start_addr, self.end_addr)

--- a/src/ssd/shell/cmd/erase_range.py
+++ b/src/ssd/shell/cmd/erase_range.py
@@ -1,8 +1,8 @@
 from ssd.shell.api import Shell
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 
 
-class EraseRangeCommand(IShellCommand):
+class EraseRangeCommand(ShellCommandInterface):
     def __init__(self, api: Shell, args: list[str]):
         super().__init__(api, args)
         self.start_addr = 0

--- a/src/ssd/shell/cmd/factory.py
+++ b/src/ssd/shell/cmd/factory.py
@@ -1,5 +1,7 @@
 from ssd.shell.api import Shell
 from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.full_read import FullReadCommand
+from ssd.shell.cmd.full_write import FullWriteCommand
 from ssd.shell.cmd.read import ReadCommand
 from ssd.shell.cmd.write import WriteCommand
 
@@ -10,6 +12,8 @@ class ShellCommandFactory:
         self.support_cmds = {
             "read": ReadCommand,
             "write": WriteCommand,
+            "fullread": FullReadCommand,
+            "fullwrite": FullWriteCommand,
             # TODO
         }
 

--- a/src/ssd/shell/cmd/factory.py
+++ b/src/ssd/shell/cmd/factory.py
@@ -1,5 +1,7 @@
 from ssd.shell.api import Shell
 from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.erase import EraseCommand
+from ssd.shell.cmd.erase_range import EraseRangeCommand
 from ssd.shell.cmd.full_read import FullReadCommand
 from ssd.shell.cmd.full_write import FullWriteCommand
 from ssd.shell.cmd.read import ReadCommand
@@ -14,6 +16,8 @@ class ShellCommandFactory:
             "write": WriteCommand,
             "fullread": FullReadCommand,
             "fullwrite": FullWriteCommand,
+            "erase": EraseCommand,
+            "erase_range": EraseRangeCommand,
             # TODO
         }
 

--- a/src/ssd/shell/cmd/factory.py
+++ b/src/ssd/shell/cmd/factory.py
@@ -2,6 +2,7 @@ from ssd.shell.api import Shell
 from ssd.shell.cmd.base import IShellCommand
 from ssd.shell.cmd.erase import EraseCommand
 from ssd.shell.cmd.erase_range import EraseRangeCommand
+from ssd.shell.cmd.flush import FlushCommand
 from ssd.shell.cmd.full_read import FullReadCommand
 from ssd.shell.cmd.full_write import FullWriteCommand
 from ssd.shell.cmd.read import ReadCommand
@@ -18,13 +19,13 @@ class ShellCommandFactory:
             "fullwrite": FullWriteCommand,
             "erase": EraseCommand,
             "erase_range": EraseRangeCommand,
-            # TODO
+            "flush": FlushCommand,
         }
 
     def parse(self, cmd_line: str) -> IShellCommand:
         parts = cmd_line.strip().split()
-
         command_name, args = parts[0], parts[1:]
+
         if command_name not in self.support_cmds:
             raise ValueError("Unknown command")
 
@@ -35,6 +36,6 @@ class ShellCommandFactory:
 if __name__ == "__main__":
     # just test
     cf = ShellCommandFactory(Shell(None))
-    ret = cf.parse("read 1")
+    ret = cf.parse("flush")
     print(ret.is_valid())
     print(ret.args)

--- a/src/ssd/shell/cmd/factory.py
+++ b/src/ssd/shell/cmd/factory.py
@@ -1,0 +1,32 @@
+from ssd.shell.api import Shell
+from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.read import ReadCommand
+from ssd.shell.cmd.write import WriteCommand
+
+
+class ShellCommandFactory:
+    def __init__(self, api: Shell):
+        self.api = api
+        self.support_cmds = {
+            "read": ReadCommand,
+            "write": WriteCommand,
+            # TODO
+        }
+
+    def parse(self, cmd_line: str) -> IShellCommand:
+        parts = cmd_line.strip().split()
+
+        command_name, args = parts[0], parts[1:]
+        if command_name not in self.support_cmds:
+            raise ValueError("Unknown command")
+
+        cmd_class = self.support_cmds[command_name]
+        return cmd_class(self.api, args)
+
+
+if __name__ == "__main__":
+    # just test
+    cf = ShellCommandFactory(Shell(None))
+    ret = cf.parse("read 1")
+    print(ret.is_valid())
+    print(ret.args)

--- a/src/ssd/shell/cmd/factory.py
+++ b/src/ssd/shell/cmd/factory.py
@@ -1,5 +1,5 @@
 from ssd.shell.api import Shell
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 from ssd.shell.cmd.erase import EraseCommand
 from ssd.shell.cmd.erase_range import EraseRangeCommand
 from ssd.shell.cmd.flush import FlushCommand
@@ -22,7 +22,7 @@ class ShellCommandFactory:
             "flush": FlushCommand,
         }
 
-    def parse(self, cmd_line: str) -> IShellCommand:
+    def parse(self, cmd_line: str) -> ShellCommandInterface:
         parts = cmd_line.strip().split()
         command_name, args = parts[0], parts[1:]
 

--- a/src/ssd/shell/cmd/flush.py
+++ b/src/ssd/shell/cmd/flush.py
@@ -1,7 +1,7 @@
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 
 
-class FlushCommand(IShellCommand):
+class FlushCommand(ShellCommandInterface):
     def is_valid(self) -> bool:
         return len(self.args) == 0
 

--- a/src/ssd/shell/cmd/flush.py
+++ b/src/ssd/shell/cmd/flush.py
@@ -8,4 +8,5 @@ class FlushCommand(IShellCommand):
     def execute(self) -> None:
         if not self.is_valid():
             self.api.help()
+            return
         self.api.flush()

--- a/src/ssd/shell/cmd/flush.py
+++ b/src/ssd/shell/cmd/flush.py
@@ -1,0 +1,11 @@
+from ssd.shell.cmd.base import IShellCommand
+
+
+class FlushCommand(IShellCommand):
+    def is_valid(self) -> bool:
+        return len(self.args) == 0
+
+    def execute(self) -> None:
+        if not self.is_valid():
+            self.api.help()
+        self.api.flush()

--- a/src/ssd/shell/cmd/full_read.py
+++ b/src/ssd/shell/cmd/full_read.py
@@ -1,0 +1,11 @@
+from ssd.shell.cmd.base import IShellCommand
+
+
+class FullReadCommand(IShellCommand):
+    def is_valid(self) -> bool:
+        return len(self.args) == 0
+
+    def execute(self) -> None:
+        if not self.is_valid():
+            self.api.help()
+        self.api.fullread()

--- a/src/ssd/shell/cmd/full_read.py
+++ b/src/ssd/shell/cmd/full_read.py
@@ -1,7 +1,7 @@
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 
 
-class FullReadCommand(IShellCommand):
+class FullReadCommand(ShellCommandInterface):
     def is_valid(self) -> bool:
         return len(self.args) == 0
 

--- a/src/ssd/shell/cmd/full_read.py
+++ b/src/ssd/shell/cmd/full_read.py
@@ -8,4 +8,5 @@ class FullReadCommand(IShellCommand):
     def execute(self) -> None:
         if not self.is_valid():
             self.api.help()
+            return
         self.api.fullread()

--- a/src/ssd/shell/cmd/full_write.py
+++ b/src/ssd/shell/cmd/full_write.py
@@ -8,4 +8,5 @@ class FullWriteCommand(IShellCommand):
     def execute(self) -> None:
         if not self.is_valid():
             self.api.help()
+            return
         self.api.fullwrite(self.args[0])

--- a/src/ssd/shell/cmd/full_write.py
+++ b/src/ssd/shell/cmd/full_write.py
@@ -1,0 +1,11 @@
+from ssd.shell.cmd.base import IShellCommand
+
+
+class FullWriteCommand(IShellCommand):
+    def is_valid(self) -> bool:
+        return len(self.args) == 1
+
+    def execute(self) -> None:
+        if not self.is_valid():
+            self.api.help()
+        self.api.fullwrite(self.args[0])

--- a/src/ssd/shell/cmd/full_write.py
+++ b/src/ssd/shell/cmd/full_write.py
@@ -1,7 +1,7 @@
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 
 
-class FullWriteCommand(IShellCommand):
+class FullWriteCommand(ShellCommandInterface):
     def is_valid(self) -> bool:
         return len(self.args) == 1
 

--- a/src/ssd/shell/cmd/read.py
+++ b/src/ssd/shell/cmd/read.py
@@ -1,8 +1,8 @@
 from ssd.shell.api import Shell
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 
 
-class ReadCommand(IShellCommand):
+class ReadCommand(ShellCommandInterface):
     def __init__(self, api: Shell, args: list[str]):
         super().__init__(api, args)
         self.address = 0

--- a/src/ssd/shell/cmd/read.py
+++ b/src/ssd/shell/cmd/read.py
@@ -16,4 +16,5 @@ class ReadCommand(IShellCommand):
     def execute(self) -> None:
         if not self.is_valid():
             self.api.help()
+            return
         self.api.read(self.address)

--- a/src/ssd/shell/cmd/read.py
+++ b/src/ssd/shell/cmd/read.py
@@ -1,0 +1,19 @@
+from ssd.shell.api import Shell
+from ssd.shell.cmd.base import IShellCommand
+
+
+class ReadCommand(IShellCommand):
+    def __init__(self, api: Shell, args: list[str]):
+        super().__init__(api, args)
+        self.address = 0
+
+    def is_valid(self) -> bool:
+        if len(self.args) != 1 or not self.args[0].isdigit():
+            return False
+        self.address = int(self.args[0])
+        return True
+
+    def execute(self) -> None:
+        if not self.is_valid():
+            self.api.help()
+        self.api.read(self.address)

--- a/src/ssd/shell/cmd/write.py
+++ b/src/ssd/shell/cmd/write.py
@@ -1,0 +1,21 @@
+from ssd.shell.api import Shell
+from ssd.shell.cmd.base import IShellCommand
+
+
+class WriteCommand(IShellCommand):
+    def __init__(self, api: Shell, args: list[str]):
+        super().__init__(api, args)
+        self.address = 0
+        self.value = ""
+
+    def is_valid(self) -> bool:
+        if len(self.args) != 2 or not self.args[0].isdigit():
+            return False
+        self.address = int(self.args[0])
+        self.value = self.args[1]
+        return True
+
+    def execute(self) -> None:
+        if not self.is_valid():
+            self.api.help()
+        self.api.write(self.address, self.value)

--- a/src/ssd/shell/cmd/write.py
+++ b/src/ssd/shell/cmd/write.py
@@ -18,4 +18,5 @@ class WriteCommand(IShellCommand):
     def execute(self) -> None:
         if not self.is_valid():
             self.api.help()
+            return
         self.api.write(self.address, self.value)

--- a/src/ssd/shell/cmd/write.py
+++ b/src/ssd/shell/cmd/write.py
@@ -1,8 +1,8 @@
 from ssd.shell.api import Shell
-from ssd.shell.cmd.base import IShellCommand
+from ssd.shell.cmd.base import ShellCommandInterface
 
 
-class WriteCommand(IShellCommand):
+class WriteCommand(ShellCommandInterface):
     def __init__(self, api: Shell, args: list[str]):
         super().__init__(api, args)
         self.address = 0


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [ ] Feature 
- [ ] Test 
- [x] Refactoring
- [ ] Bug fix
- [ ] Non-code (ex. documentation update)

  <br/>
## Description
## 🔎 작업 내용

- flush api 추가 및 버그 수정
- 기존 shell app에서 `do_XX()` 대신 `IShellCommand` 객체를 실행하도록 변경
- 단 help()와 exit()은 예외.
- argument를 split하고 cmd를 알아내는 건 `ShellCommandFactory`가 수행
- argument 개수 검증과 타입 검증은 `IShellCommand.is_valid()`가 수행
- 변경 전후 별다른 이상 없음
![image](https://github.com/demianmedich/SSD/assets/52237832/8a9ce957-2079-49f8-932c-c69a025738c8)


  <br/>

## Future work
- shell.api.Shell을 그대로 둘 지 각각에 대한 수치 검증과 SSD 명령 실행도 IShellCommand로 옮길 지는 고민 중입니다.

  <br/>

